### PR TITLE
Refactors input keyboard navigation

### DIFF
--- a/src/app/submit/page.jsx
+++ b/src/app/submit/page.jsx
@@ -35,16 +35,25 @@ class MyMouserSensor extends MouseSensor {
   ];
 }
 
-function MovieResultList({ movies, onSelect, imageConfig, selectedIndex, setSelectedIndex }) {
+function MovieResultList({
+  movies, 
+  onSelect, 
+  imageConfig, 
+  selectedIndex, 
+  setSelectedIndex,
+  disableHoverSelect
+}) {
   const handleHover = useCallback((e, index) => {
-    setSelectedIndex(index);
+    if (!disableHoverSelect) {
+      setSelectedIndex(index);
+    }
   });
 
   return (
     <div>
         <ul>
           {movies.map((movie, i) => (
-            <li key={`${movie.title}-${movie.id}`} onMouseOver={(e) => handleHover(e, i)}>
+            <li key={`${movie.title}-${movie.id}`} onMouseEnter={(e) => handleHover(e, i)}>
               <MovieItem movie={movie} onSelect={onSelect} imageConfig={imageConfig} selected={i === selectedIndex}/>
             </li>
           ))}
@@ -127,6 +136,7 @@ function ChooseMovieModal({ initialValue = '', onSelect, imageConfig, setShowMod
   const [val, setVal] = useState(initialValue);
   const [movies, setMovies] = useState([]);
   const [selectedIndex, setSelectedIndex] = useState(0)
+  const [disableHoverSelect, setDisableHoverSelect] = useState(false);
   const ref = useRef()
 
   const onMovieChange = useCallback((pattern) => {
@@ -138,17 +148,22 @@ function ChooseMovieModal({ initialValue = '', onSelect, imageConfig, setShowMod
   const onKeyDown = useCallback((event) => {
     if (event.code === 'ArrowUp') {
       event.preventDefault();
+      setDisableHoverSelect(true);
       setSelectedIndex(selectedIndex === 0 ? 0 : selectedIndex - 1)
     } else if (event.code === 'ArrowDown') {
       event.preventDefault();
+      setDisableHoverSelect(true);
       setSelectedIndex(selectedIndex === movies.length - 1 ? 0 : selectedIndex + 1)
     } else if (event.code === 'Enter') {
       event.preventDefault();
+      setDisableHoverSelect(false);
       onSelect(movies[selectedIndex], true)
     } else if (event.code === 'Escape') {
       event.preventDefault();
+      setDisableHoverSelect(false);
       cancelSearch();
     } else {
+      setDisableHoverSelect(false);
       setSelectedIndex(0);
     }
   });
@@ -198,6 +213,7 @@ function ChooseMovieModal({ initialValue = '', onSelect, imageConfig, setShowMod
           imageConfig={imageConfig} 
           selectedIndex={selectedIndex}
           setSelectedIndex={setSelectedIndex}
+          disableHoverSelect={disableHoverSelect}
         />
       </section>
     </div>

--- a/src/components/input.jsx
+++ b/src/components/input.jsx
@@ -4,30 +4,12 @@ import { useCallback } from 'react';
 
 export function Input(options) {
   const noop = () => null;
-  const { value, label, id, onChange = noop, selectedIndex = 0, setSelectedIndex = noop, ref = null, movies = [], onSelect = noop, ...rest } = options;
+  const { value, label, id, onChange = noop, ref = null, onKeyDown = noop, ...rest } = options;
 
   const internalOnChange = useCallback((e) => {
     const updatedValue = e.currentTarget.value;
     onChange(updatedValue);
   }, [onChange]);
-
-  const keyNavigation = (event) => {
-    console.log('key press', event.code);
-    if (event.code === 'ArrowUp') {
-      event.preventDefault()
-      setSelectedIndex(selectedIndex === 0 ? 0 : selectedIndex - 1)
-    } else if (event.code === 'ArrowDown') {
-      event.preventDefault()
-      setSelectedIndex(selectedIndex === movies.length - 1 ? 0 : selectedIndex + 1)
-    } else if (event.code === 'Enter') {
-      console.log('LOG: pressed "ENTER"')
-      event.preventDefault()
-      onSelect(movies[selectedIndex], true)
-    } else {
-      console.log('LOG: else branch');
-      setSelectedIndex(0)
-    }
-  }
 
   return (
     <div className="mb-10">
@@ -40,7 +22,7 @@ export function Input(options) {
           onChange={internalOnChange} 
           id={id}
           ref={ref}
-          onKeyDown={e => keyNavigation(e)}
+          onKeyDown={onKeyDown}
         />
       </div>
     </div>


### PR DESCRIPTION
Keyboard nav should be handled outside of input component and passed in when needed. This allowed the ESCAPE key to be handled at the same time as the other keys, and removes need to pass in `movies` and `onSelect`. 

Hover is no longer styled with the same as the "selected" style which caused duplicate styling when you hover onto something and then arrow key away from it. Hover DOES now set the selected state.

Items that are selected off-screen are scrolled into view based on the nearest edge.