### PR TITLE
Fixes bug if you hit enter too quick

### DIFF
--- a/src/app/[userId]/my25/page.jsx
+++ b/src/app/[userId]/my25/page.jsx
@@ -29,6 +29,10 @@ export default function SubmitFilms() {
   }
 
   const onFavoriteSelect = useCallback((movie, enterSelect = false) => {
+    if (!movie) {
+      return;
+    }
+    
     if (favorites.some(fav => fav.id === movie.id)) {
       resetAlert({style: 'warning', message: `${movie.title} is already on list`})
     } else {


### PR DESCRIPTION
If you push [Enter] too quickly when you're searching, it tries to add a null movie to your list which blows up. This prevents submitting when the movie is null.