### PR TITLE
fixing enter key on input field

### DIFF
--- a/src/app/my25/[userId]/components/ImportMovies.jsx
+++ b/src/app/my25/[userId]/components/ImportMovies.jsx
@@ -9,6 +9,14 @@ export function ImportMovies({ onImportSuccess, onImportFailure }) {
   const [inputValue, setInputValue] = useState('');
   const [isImporting, setIsImporting] = useState(false);
 
+  const handleKeyDownCapture = (event) => {
+    if (event.key === 'Enter' && isExpanded) {
+      event.stopPropagation();
+      event.preventDefault();
+      handleImport();
+    }
+  };
+
   const handleImport = async () => {
     setIsExpanded(false);
     setIsImporting(true);
@@ -41,6 +49,7 @@ export function ImportMovies({ onImportSuccess, onImportFailure }) {
             onChange={(e) => setInputValue(e.target.value)}
             placeholder="Enter Public Letterboxd List URL"
             className="p-2 m-2 border border-gray-300 rounded w-72"
+            onKeyDownCapture={handleKeyDownCapture}
           />
           <button
             onClick={handleImport}


### PR DESCRIPTION
### Notes
The add movie modal captures the enter button, even when you are importing movies. This means that when you paste a Letterboxd url enter the import field and hit enter the 'add a movie' modal opens. This change checks to see if the import button has been clicked and the import text field has been expanded. If it has, it will take priority and do the import and prevent the modal from capturing the event. In all other cases the default enter key handling happens. 

### Testing
- On the main page, hit `enter` and observed the `add movie` modal
- Hit the `import` button and entered a list url. Hit `enter` and verified the movie list was imported and no modal was opened.
- After the import completed, hit `enter` again and observed the `add movie` modal opened