### PR TITLE
Fixes incorrect user/list relationship

### DIFF
--- a/prisma/migrations/20250110191546_fix_list_user_relation/migration.sql
+++ b/prisma/migrations/20250110191546_fix_list_user_relation/migration.sql
@@ -1,0 +1,21 @@
+/*
+  Warnings:
+
+  - You are about to drop the `ListsOnUser` table. If the table is not empty, all the data it contains will be lost.
+  - Added the required column `user_id` to the `List` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "ListsOnUser" DROP CONSTRAINT "ListsOnUser_list_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "ListsOnUser" DROP CONSTRAINT "ListsOnUser_user_id_fkey";
+
+-- AlterTable
+ALTER TABLE "List" ADD COLUMN     "user_id" INTEGER NOT NULL;
+
+-- DropTable
+DROP TABLE "ListsOnUser";
+
+-- AddForeignKey
+ALTER TABLE "List" ADD CONSTRAINT "List_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -29,14 +29,15 @@ model User {
   hashed_password    String
   slack_user_id      String?
   tokens             Token[]
-  lists              ListsOnUser[]
+  lists              List[]
 }
 
 model List {
   id          Int               @id @default(autoincrement())
   type        MovieListType
   movies      MoviesOnList[]
-  users       ListsOnUser[]
+  user        User              @relation(fields: [user_id], references: [id])
+  user_id     Int
 }
 
 model MoviesOnList {
@@ -47,15 +48,6 @@ model MoviesOnList {
   order      Int
 
   @@id(name: "movie_list_id", fields: [movie_id, list_id])
-}
-
-model ListsOnUser {
-  list       List    @relation(fields: [list_id], references: [id])
-  list_id    Int
-  user       User    @relation(fields: [user_id], references: [id])
-  user_id    Int
-
-  @@id(name: "list_user_id", fields: [list_id, user_id])
 }
 
 model Token {


### PR DESCRIPTION
I had modeled the user/list relationship as many-to-many but in fact it's one-to-many, each list has only one user attached.

I've already updated the db with this change, so that may cause errors in your local client. The prisma client gets rebuilt when the whole app builds, so the prod env will be fine once we push again, but for local dev, I recommend pulling these changes and then running `npx prisma generate` to re-generate your client locally.