### PR TITLE
Implements list crud interface methods 

### DIFF
--- a/prisma/migrations/20250110212825_referential_actions/migration.sql
+++ b/prisma/migrations/20250110212825_referential_actions/migration.sql
@@ -1,0 +1,17 @@
+-- DropForeignKey
+ALTER TABLE "List" DROP CONSTRAINT "List_user_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "MoviesOnList" DROP CONSTRAINT "MoviesOnList_list_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Token" DROP CONSTRAINT "Token_user_id_fkey";
+
+-- AddForeignKey
+ALTER TABLE "List" ADD CONSTRAINT "List_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MoviesOnList" ADD CONSTRAINT "MoviesOnList_list_id_fkey" FOREIGN KEY ("list_id") REFERENCES "List"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Token" ADD CONSTRAINT "Token_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20250111170338_simplify_list_entry_relations/migration.sql
+++ b/prisma/migrations/20250111170338_simplify_list_entry_relations/migration.sql
@@ -1,0 +1,40 @@
+/*
+  Warnings:
+
+  - You are about to drop the `List` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `MoviesOnList` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "List" DROP CONSTRAINT "List_user_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "MoviesOnList" DROP CONSTRAINT "MoviesOnList_list_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "MoviesOnList" DROP CONSTRAINT "MoviesOnList_movie_id_fkey";
+
+-- DropTable
+DROP TABLE "List";
+
+-- DropTable
+DROP TABLE "MoviesOnList";
+
+-- CreateTable
+CREATE TABLE "ListEntry" (
+    "movie_id" INTEGER NOT NULL,
+    "user_id" INTEGER NOT NULL,
+    "type" "MovieListType" NOT NULL,
+    "order" INTEGER NOT NULL,
+
+    CONSTRAINT "ListEntry_pkey" PRIMARY KEY ("movie_id","user_id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ListEntry_user_id_type_order_key" ON "ListEntry"("user_id", "type", "order");
+
+-- AddForeignKey
+ALTER TABLE "ListEntry" ADD CONSTRAINT "ListEntry_movie_id_fkey" FOREIGN KEY ("movie_id") REFERENCES "Movie"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ListEntry" ADD CONSTRAINT "ListEntry_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -58,6 +58,6 @@ model Movie {
   title           String
   release_date    DateTime        @db.Date
   poster_path     String?
-  list_links      ListEntry[]
+  list_entries    ListEntry[]
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -29,31 +29,25 @@ model User {
   hashed_password    String
   slack_user_id      String?
   tokens             Token[]
-  lists              List[]
+  list_entries       ListEntry[]
 }
 
-model List {
-  id          Int               @id @default(autoincrement())
-  type        MovieListType
-  movies      MoviesOnList[]
-  user        User              @relation(fields: [user_id], references: [id])
-  user_id     Int
-}
-
-model MoviesOnList {
-  movie      Movie     @relation(fields: [movie_id], references: [id])
+model ListEntry {
+  movie      Movie    @relation(fields: [movie_id], references: [id], onDelete: Restrict, onUpdate: Cascade)
   movie_id   Int
-  list       List      @relation(fields: [list_id], references: [id])
-  list_id    Int
+  user       User     @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  user_id    Int
+  type       MovieListType
   order      Int
 
-  @@id(name: "movie_list_id", fields: [movie_id, list_id])
+  @@id(name: "list_entry_id", fields: [movie_id, user_id])
+  @@unique([user_id, type, order])
 }
 
 model Token {
   id           String      @id @default(uuid())
   created_at   DateTime    @default(now())
-  user         User        @relation(fields: [user_id], references: [id])
+  user         User        @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: Cascade)
   user_id      Int
   type         TokenType   @default(AUTH)
 }
@@ -64,6 +58,6 @@ model Movie {
   title           String
   release_date    DateTime        @db.Date
   poster_path     String?
-  lists           MoviesOnList[]
+  list_links      ListEntry[]
 }
 

--- a/src/app/jason_test/page.jsx
+++ b/src/app/jason_test/page.jsx
@@ -1,0 +1,88 @@
+'use client';
+
+import React, { useState, useEffect, useCallback } from 'react';
+import { getSession } from '@/lib/session';
+import { getLists, saveLists } from '@/lib/db';
+
+function shuffle(list) {
+  return list
+    .map((value) => ({ value, sort: Math.random() }))
+    .sort((a, b) => a.sort - b.sort)
+    .map(({ value }) => value);
+}
+
+export default function TestPage({ params }) {
+  const [activeSession, setActiveSession] = useState(false);
+  const [lists, setLists] = useState({ favorites: [], hms: [], queue: [] });
+  const [isShuffling, setIsShuffling] = useState(false);
+
+  useEffect(() => {
+    async function retrieve() {
+      if (!activeSession) {
+        const session = await getSession();
+        if (session) {
+          setActiveSession(session);
+          const storedLists = await getLists({ user_id: session.user.id });
+          setLists(storedLists);
+        }
+      }
+    }
+
+    retrieve();
+  }, [activeSession, setActiveSession, setLists]);
+
+  const shuffleLists = useCallback(async () => {
+    const shuffled = [
+      { type: 'FAVORITE', movies: shuffle(lists.favorites) },
+      { type: 'HM', movies: shuffle(lists.hms) },
+      { type: 'QUEUE', movies: shuffle(lists.queue) }
+    ];
+    console.log('shuffled lists, about to save', shuffled);
+
+    const { saved } = await saveLists({
+      user_id: activeSession.user.id,
+      lists: shuffled
+    });
+
+    console.log('saved?', saved);
+
+    setLists(saved);
+  }, [lists, getLists]);
+
+  if (!activeSession) {
+    return <p>You need to be logged in as this user to view this page.</p>;
+  }
+
+  return (
+    <div>
+      <h1 className="mb-5">Testing Database Persistence</h1>
+      <div className="mb-5">
+        <p>Below, you should see your lists, as they are stored in the db.</p>
+        <p>If you have no lists stored in the db, they will all be empty.</p>
+      </div>
+      <div>
+        <OrderedMovieList title="Favorites" list={lists.favorites} />
+        <OrderedMovieList title="Honorable Mentions" list={lists.hms} />
+        <OrderedMovieList title="Queue" list={lists.queue} />
+      </div>
+      <button href="#" onClick={shuffleLists} disabled={isShuffling}>
+        {isShuffling
+          ? 'Re-shuffling and saving...'
+          : 'Re-shuffle and save my lists!'}
+      </button>
+    </div>
+  );
+}
+
+function OrderedMovieList({ title, list }) {
+  return (
+    <div className="mb-5">
+      <h3 className="font-bold mb-2">{title}</h3>
+      <ol className="list-decimal mb-3">
+        {list.map((item) => (
+          <li key={item.id}>{item.title}</li>
+        ))}
+      </ol>
+    </div>
+  );
+}

--- a/src/app/my25/[username]/page.jsx
+++ b/src/app/my25/[username]/page.jsx
@@ -36,10 +36,6 @@ export default function SubmitFilms({ params }) {
         const session = await getSession();
         if (session && session?.user?.username === p.username) {
           setActiveSession(true);
-
-          // TEST getLists() -- TODO: remove later
-          const lists = await getLists({ user_id: session.user.id });
-          console.log('found lists!', lists);
         }
       }
       const config = await getTmdbConfig();

--- a/src/app/my25/[username]/page.jsx
+++ b/src/app/my25/[username]/page.jsx
@@ -9,6 +9,7 @@ import { ImportMovies } from './components/ImportMovies';
 import { COUNTED, NUM_RATED } from '@/lib/constants';
 import { getSession } from '@/lib/session';
 import Link from 'next/link';
+import { getLists } from '@/lib/db';
 
 function labelFromListLength(length) {
   if (length > COUNTED) {
@@ -31,12 +32,14 @@ export default function SubmitFilms({ params }) {
   useEffect(() => {
     async function retrieve() {
       const p = await params;
-      console.log('params', p);
       if (!activeSession) {
         const session = await getSession();
-        console.log('session', session);
         if (session && session?.user?.username === p.username) {
           setActiveSession(true);
+
+          // TEST getLists() -- TODO: remove later
+          const lists = await getLists({ user_id: session.user.id });
+          console.log('found lists!', lists);
         }
       }
       const config = await getTmdbConfig();

--- a/src/app/slack-login/page.jsx
+++ b/src/app/slack-login/page.jsx
@@ -28,7 +28,6 @@ function ShowToken() {
     async function retrieve() {
       setLoading(true);
       const record = await getAuthTokenRecord({ token: authToken });
-      console.log('found auth token record', record);
       if (record?.user) {
         setUser(record.user);
         delete record.user.hashedPassword;
@@ -53,18 +52,4 @@ function ShowToken() {
   }
 
   return <p>Redirecting...</p>;
-
-  // return (
-  //   <div>
-  //     <p>Token: {authToken}</p>
-  //     <p>User:</p>
-  //     <>
-  //       (user ? (
-  //       <pre>
-  //         <code>{JSON.stringify(user, null, 2)}</code>
-  //       </pre>
-  //       ) : null)
-  //     </>
-  //   </div>
-  // );
 }

--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -154,13 +154,9 @@ export async function getAuthTokenRecord({ token }) {
 
 export async function getLists({ user_id }) {
   logger.debug(`Attempting to get lists for user ${user_id}`);
-  const movies = await prisma.moviesOnList.findMany({
+  const movies = await prisma.listEntry.findMany({
     where: {
-      list: {
-        is: {
-          user_id
-        }
-      }
+      user_id
     },
     orderBy: [
       {
@@ -168,7 +164,6 @@ export async function getLists({ user_id }) {
       }
     ],
     include: {
-      list: true,
       movie: true
     }
   });
@@ -181,19 +176,19 @@ export async function getLists({ user_id }) {
     return init;
   }
 
-  return movies.reduce((results, item) => {
-    switch (item.list.type) {
+  return movies.reduce((results, entry) => {
+    switch (entry.type) {
       case MovieListType.FAVORITE: {
-        results.favorites.push(item.movie);
+        results.favorites.push(entry.movie);
         break;
       }
       case MovieListType.HM: {
-        results.hms.push(item.movie);
+        results.hms.push(entry.movie);
         break;
       }
       case MovieListType.QUEUE:
       default: {
-        results.queue.push(item.movie);
+        results.queue.push(entry.movie);
       }
     }
     return results;
@@ -202,7 +197,32 @@ export async function getLists({ user_id }) {
 
 // lists should be an array of { type, movies }
 export async function saveLists({ user_id, lists }) {
-  // TODO: NOT IMPLEMENTED
+  // This function is WIP, I re-designed the data model mid-stream
+  // const types = lists.map((list) => list.type);
+
+  // // wishing I had TypeScript right now
+  // const validTypes = Object.values(MovieListType);
+  // if (types.some((t) => !validTypes.includes(t))) {
+  //   throw new Error(
+  //     `Invalid type included in saveLists call, lists not saved (${types.join(', ')})`
+  //   );
+  // }
+
+  // const results = await prisma.$transaction([
+  //   // Step 1: Delete all incoming lists
+  //   prisma.list.deleteMany({
+  //     where: {
+  //       user_id,
+  //       type: {
+  //         in: types
+  //       }
+  //     }
+  //   }),
+  //   ...(types.map(
+  //     (type) => prisma.list.
+  //   ))
+  // ]);
+
   const summary = lists
     .map((l) => `${l.type}: ${l.movies.length} movies`)
     .join(', ');

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -5,7 +5,11 @@
 async function log(...messages) {
   if (typeof messages[0] === 'function') {
     const computedMessage = await messages[0]();
-    log(computedMessage);
+    if (Array.isArray(computedMessage)) {
+      log(...computedMessage);
+    } else {
+      log(computedMessage);
+    }
   } else {
     // eslint-disable-next-line
     console.log(...messages);


### PR DESCRIPTION
This PR will implement the getLists and saveLists methods which are no-ops right now.

Both methods are now implemented, the schema has changed a bit, and there is a test page at jason_test that works for Paul and I to see how it loads your list from the db and then re-saves it in a different order (randomized). 