### PR TITLE
Material tailwind + admin users table + separate admin "peek" page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@material-tailwind/react": "^2.1.10",
         "@prisma/client": "^6.1.0",
         "@tabler/icons-react": "^3.26.0",
         "axios": "^1.7.9",
@@ -656,6 +657,23 @@
         "react": ">=16.8.0"
       }
     },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emotion/memoize": "0.7.4"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
@@ -795,6 +813,59 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
+      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
+      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.19.0.tgz",
+      "integrity": "sha512-fgYvN4ksCi5OvmPXkyOT8o5a8PSKHMzPHt+9mR6KYWdF16IAjWRLZPAAziI2sznaWT23drRFrYw64wdvYqqaQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^1.2.2",
+        "aria-hidden": "^1.1.3",
+        "tabbable": "^6.0.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-1.3.0.tgz",
+      "integrity": "sha512-htwHm67Ji5E/pROEAr7f8IKFShuiCKHwUC/UY4vC3I5jiSvGFAYnSYiZO5MlGmads+QqvUkR9ANHEguGrDv72g==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.2.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
+      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
+      "license": "MIT"
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -1457,6 +1528,134 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@material-tailwind/react": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@material-tailwind/react/-/react-2.1.10.tgz",
+      "integrity": "sha512-xGU/mLDKDBp/qZ8Dp2XR7fKcTpDuFeZEBqoL9Bk/29kakKxNxjUGYSRHEFLsyOFf4VIhU6WGHdIS7tOA3QGJHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "0.19.0",
+        "classnames": "2.3.2",
+        "deepmerge": "4.2.2",
+        "framer-motion": "6.5.1",
+        "material-ripple-effects": "2.0.1",
+        "prop-types": "15.8.1",
+        "react": "18.2.0",
+        "react-dom": "18.2.0",
+        "tailwind-merge": "1.8.1"
+      },
+      "peerDependencies": {
+        "react": "^16 || ^17 || ^18",
+        "react-dom": "^16 || ^17 || ^18"
+      }
+    },
+    "node_modules/@material-tailwind/react/node_modules/deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@material-tailwind/react/node_modules/react": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@material-tailwind/react/node_modules/react-dom": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0"
+      }
+    },
+    "node_modules/@material-tailwind/react/node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/@motionone/animation": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/@motionone/animation/-/animation-10.18.0.tgz",
+      "integrity": "sha512-9z2p5GFGCm0gBsZbi8rVMOAJCtw1WqBTIPw3ozk06gDvZInBPIsQcHgYogEJ4yuHJ+akuW8g1SEIOpTOvYs8hw==",
+      "license": "MIT",
+      "dependencies": {
+        "@motionone/easing": "^10.18.0",
+        "@motionone/types": "^10.17.1",
+        "@motionone/utils": "^10.18.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@motionone/dom": {
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@motionone/dom/-/dom-10.12.0.tgz",
+      "integrity": "sha512-UdPTtLMAktHiqV0atOczNYyDd/d8Cf5fFsd1tua03PqTwwCe/6lwhLSQ8a7TbnQ5SN0gm44N1slBfj+ORIhrqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@motionone/animation": "^10.12.0",
+        "@motionone/generators": "^10.12.0",
+        "@motionone/types": "^10.12.0",
+        "@motionone/utils": "^10.12.0",
+        "hey-listen": "^1.0.8",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@motionone/easing": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/@motionone/easing/-/easing-10.18.0.tgz",
+      "integrity": "sha512-VcjByo7XpdLS4o9T8t99JtgxkdMcNWD3yHU/n6CLEz3bkmKDRZyYQ/wmSf6daum8ZXqfUAgFeCZSpJZIMxaCzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@motionone/utils": "^10.18.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@motionone/generators": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/@motionone/generators/-/generators-10.18.0.tgz",
+      "integrity": "sha512-+qfkC2DtkDj4tHPu+AFKVfR/C30O1vYdvsGYaR13W/1cczPrrcjdvYCj0VLFuRMN+lP1xvpNZHCRNM4fBzn1jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@motionone/types": "^10.17.1",
+        "@motionone/utils": "^10.18.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@motionone/types": {
+      "version": "10.17.1",
+      "resolved": "https://registry.npmjs.org/@motionone/types/-/types-10.17.1.tgz",
+      "integrity": "sha512-KaC4kgiODDz8hswCrS0btrVrzyU2CSQKO7Ps90ibBVSQmjkrt2teqta6/sOG59v7+dPnKMAg13jyqtMKV2yJ7A==",
+      "license": "MIT"
+    },
+    "node_modules/@motionone/utils": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/@motionone/utils/-/utils-10.18.0.tgz",
+      "integrity": "sha512-3XVF7sgyTSI2KWvTf6uLlBJ5iAgRgmvp3bpuOiQJvInd4nZ19ET8lX5unn30SlmRH7hXbBbH+Gxd0m0klJ3Xtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@motionone/types": "^10.17.1",
+        "hey-listen": "^1.0.8",
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@next/env": {
@@ -2443,6 +2642,18 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-hidden": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.4.tgz",
+      "integrity": "sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/aria-query": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
@@ -3130,6 +3341,12 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.1.tgz",
       "integrity": "sha512-cuSVIHi9/9E/+821Qjdvngor+xpnlwnuwIyZOaLmHBVdXL+gP+I6QQB9VkO7RI77YIcTV+S1W9AreJ5eN63JBA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/classnames": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==",
       "license": "MIT"
     },
     "node_modules/cli-cursor": {
@@ -4961,6 +5178,36 @@
         "node": ">= 6"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-6.5.1.tgz",
+      "integrity": "sha512-o1BGqqposwi7cgDrtg0dNONhkmPsUFDaLcKXigzuTFC5x58mE8iyTazxSudFzmT6MEyJKfjjU8ItoMe3W+3fiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@motionone/dom": "10.12.0",
+        "framesync": "6.0.1",
+        "hey-listen": "^1.0.8",
+        "popmotion": "11.0.3",
+        "style-value-types": "5.0.0",
+        "tslib": "^2.1.0"
+      },
+      "optionalDependencies": {
+        "@emotion/is-prop-valid": "^0.8.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.8 || ^17.0.0 || ^18.0.0",
+        "react-dom": ">=16.8 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/framesync": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.0.1.tgz",
+      "integrity": "sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -5412,6 +5659,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/hey-listen": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
+      "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==",
+      "license": "MIT"
     },
     "node_modules/html-encoding-sniffer": {
       "version": "2.0.1",
@@ -8353,7 +8606,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -8418,6 +8670,12 @@
       "dependencies": {
         "tmpl": "1.0.5"
       }
+    },
+    "node_modules/material-ripple-effects": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/material-ripple-effects/-/material-ripple-effects-2.0.1.tgz",
+      "integrity": "sha512-hHlUkZAuXbP94lu02VgrPidbZ3hBtgXBtjlwR8APNqOIgDZMV8MCIcsclL8FmGJQHvnORyvoQgC965vPsiyXLQ==",
+      "license": "MIT"
     },
     "node_modules/math-intrinsics": {
       "version": "1.0.0",
@@ -8757,7 +9015,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -9244,6 +9501,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/popmotion": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-11.0.3.tgz",
+      "integrity": "sha512-Y55FLdj3UxkR7Vl3s7Qr4e9m0onSnP8W7d/xQLsoJM40vs6UKHFdygs6SWryasTZYqugMjm3BepCF4CWXDiHgA==",
+      "license": "MIT",
+      "dependencies": {
+        "framesync": "6.0.1",
+        "hey-listen": "^1.0.8",
+        "style-value-types": "5.0.0",
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -9907,7 +10176,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -10022,7 +10290,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/read-cache": {
@@ -11047,6 +11314,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/style-value-types": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-5.0.0.tgz",
+      "integrity": "sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==",
+      "license": "MIT",
+      "dependencies": {
+        "hey-listen": "^1.0.8",
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -11138,6 +11415,18 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+      "license": "MIT"
+    },
+    "node_modules/tailwind-merge": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-1.8.1.tgz",
+      "integrity": "sha512-+fflfPxvHFr81hTJpQ3MIwtqgvefHZFUHFiIHpVIRXvG/nX9+gu2P7JNlFu2bfDMJ+uHhi/pUgzaYacMoXv+Ww==",
       "license": "MIT"
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@material-tailwind/react": "^2.1.10",
     "@prisma/client": "^6.1.0",
     "@tabler/icons-react": "^3.26.0",
     "axios": "^1.7.9",

--- a/src/app/admin/users/page.jsx
+++ b/src/app/admin/users/page.jsx
@@ -5,7 +5,6 @@ import { getAllUsers } from '@/lib/db';
 import { useState, useEffect } from 'react';
 import { BasicTable } from '@/components/BasicTable';
 import Link from 'next/link';
-import { Button } from '@/components/MaterialTailwind';
 import { IconLink } from '@tabler/icons-react';
 
 export default function AuthAdminUserListPage({ params: asyncParams }) {

--- a/src/app/admin/users/page.jsx
+++ b/src/app/admin/users/page.jsx
@@ -3,6 +3,10 @@
 import { AdminAuthenticatedPage } from '@/components/AuthenticatedPage';
 import { getAllUsers } from '@/lib/db';
 import { useState, useEffect } from 'react';
+import { BasicTable } from '@/components/BasicTable';
+import Link from 'next/link';
+import { Button } from '@/components/MaterialTailwind';
+import { IconLink } from '@tabler/icons-react';
 
 export default function AuthAdminUserListPage({ params: asyncParams }) {
   return (
@@ -30,16 +34,43 @@ function AdminUserListPage({ params, user, session, router }) {
     retreive();
   }, []);
 
+  const columns = [
+    {
+      key: 'id',
+      label: 'ID',
+      cellClasses: 'text-center'
+    },
+    {
+      key: 'username',
+      label: 'Username'
+    },
+    {
+      key: 'role',
+      label: 'Role'
+    },
+    {
+      key: 'links',
+      label: 'Rankings',
+      cell: (row) => (
+        <div>
+          <Link
+            className="text-blue-gray-800 hover:underline flex"
+            href={`/admin/users/peek?username=${row.username}&ranking=all-time`}>
+            <IconLink className="pt-1 mr-1" size={20} /> All Time
+          </Link>
+        </div>
+      )
+    }
+  ];
+
   return (
     <div>
       <h1>Admin Only: User List</h1>
-      <ol className="list-decimal">
-        {users.map((user) => (
-          <li key={user.id}>
-            ({user.id}) {user.username} | {user.role}
-          </li>
-        ))}
-      </ol>
+      <BasicTable
+        columns={columns}
+        rows={users}
+        options={{ getRowKey: (row) => row.id }}
+      />
     </div>
   );
 }

--- a/src/app/admin/users/peek/page.jsx
+++ b/src/app/admin/users/peek/page.jsx
@@ -46,37 +46,41 @@ function AdminUserPeek({ username, rankingSlug, imageConfig }) {
 
   return (
     <div>
-      <Link className="underline" href="/admin/users">
-        Back to all users
-      </Link>
-      <h1 className="text-xl">Admin View</h1>
-      <p>Ranking: {ranking.name}</p>
-      <p>User: {username}</p>
       {!focusMovie ? (
-        <div className="my-5">
-          <h2 className="font-bold text-lg mb-3">Favorites</h2>
-          <div className="flex flex-wrap gap-4 justify-start mb-5">
-            {lists.FAVORITE.map((film) => (
-              <MovieGridPoster
-                key={film.id}
-                movie={film}
-                size="sm"
-                imageConfig={imageConfig}
-                setFocus={setFocusMovie}
-              />
-            ))}
+        <div>
+          <div>
+            <Link className="underline" href="/admin/users">
+              Back to all users
+            </Link>
+            <h1 className="text-xl">Admin View</h1>
+            <p>Ranking: {ranking.name}</p>
+            <p>User: {username}</p>
           </div>
-          <h2 className="font-bold text-lg mb-3">Honorable Mentions</h2>
-          <div className="flex flex-wrap gap-2 justify-start">
-            {lists.HM.map((film) => (
-              <MovieGridPoster
-                key={film.id}
-                movie={film}
-                size="xs"
-                imageConfig={imageConfig}
-                setFocus={setFocusMovie}
-              />
-            ))}
+          <div className="my-5">
+            <h2 className="font-bold text-lg mb-3">Favorites</h2>
+            <div className="flex flex-wrap gap-4 justify-start mb-5">
+              {lists.FAVORITE.map((film) => (
+                <MovieGridPoster
+                  key={film.id}
+                  movie={film}
+                  size="sm"
+                  imageConfig={imageConfig}
+                  setFocus={setFocusMovie}
+                />
+              ))}
+            </div>
+            <h2 className="font-bold text-lg mb-3">Honorable Mentions</h2>
+            <div className="flex flex-wrap gap-2 justify-start">
+              {lists.HM.map((film) => (
+                <MovieGridPoster
+                  key={film.id}
+                  movie={film}
+                  size="xs"
+                  imageConfig={imageConfig}
+                  setFocus={setFocusMovie}
+                />
+              ))}
+            </div>
           </div>
         </div>
       ) : (

--- a/src/app/admin/users/peek/page.jsx
+++ b/src/app/admin/users/peek/page.jsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { AdminAuthenticatedPage } from '@/components/AuthenticatedPage';
+import { Button, Typography } from '@/components/MaterialTailwind';
+import useRankingForUser from '@/hooks/useRankingForUser';
+import useTmdbImageConfig from '@/hooks/useTmdbImageConfig';
+import { buildImageUrl } from '@/lib/buildImageUrl';
+import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
+import { useState } from 'react';
+
+export default function AuthAdminUserPeek({ params: asyncParams }) {
+  const searchParams = useSearchParams();
+  const username = searchParams.get('username');
+  const rankingSlug = searchParams.get('ranking');
+  const imageConfig = useTmdbImageConfig();
+
+  return (
+    <AdminAuthenticatedPage asyncParams={asyncParams}>
+      {({ session, params, router }) => {
+        if (!searchParams.has('username') || !searchParams.has('ranking')) {
+          return 'This page requires ?username=x&ranking=y';
+        }
+        return (
+          <AdminUserPeek
+            session={session}
+            params={params}
+            username={username}
+            rankingSlug={rankingSlug}
+            router={router}
+            imageConfig={imageConfig}
+          />
+        );
+      }}
+    </AdminAuthenticatedPage>
+  );
+}
+
+function AdminUserPeek({ username, rankingSlug, imageConfig }) {
+  const [focusMovie, setFocusMovie] = useState(null);
+  const { ranking, lists } = useRankingForUser({ username, rankingSlug });
+
+  if (!ranking || !lists) {
+    return null;
+  }
+
+  return (
+    <div>
+      <Link className="underline" href="/admin/users">
+        Back to all users
+      </Link>
+      <h1 className="text-xl">Admin View</h1>
+      <p>Ranking: {ranking.name}</p>
+      <p>User: {username}</p>
+      {!focusMovie ? (
+        <div className="my-5">
+          <h2 className="font-bold text-lg mb-3">Favorites</h2>
+          <div className="flex flex-wrap gap-4 justify-start mb-5">
+            {lists.FAVORITE.map((film) => (
+              <MovieGridPoster
+                key={film.id}
+                movie={film}
+                size="sm"
+                imageConfig={imageConfig}
+                setFocus={setFocusMovie}
+              />
+            ))}
+          </div>
+          <h2 className="font-bold text-lg mb-3">Honorable Mentions</h2>
+          <div className="flex flex-wrap gap-2 justify-start">
+            {lists.HM.map((film) => (
+              <MovieGridPoster
+                key={film.id}
+                movie={film}
+                size="xs"
+                imageConfig={imageConfig}
+                setFocus={setFocusMovie}
+              />
+            ))}
+          </div>
+        </div>
+      ) : (
+        <div className="w-full h-[150px] my-5">
+          <Typography className="mb-3 text-xl">
+            {getMovieTitle(focusMovie)}
+          </Typography>
+          <Button className="w-full mb-3" onClick={() => setFocusMovie(null)}>
+            Back to Ranking
+          </Button>
+          <img
+            className="mb-3"
+            alt={focusMovie.title}
+            src={buildImageUrl({
+              config: imageConfig,
+              size: 'lg',
+              path: focusMovie.poster_path
+            })}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MovieGridPoster({ movie, imageConfig, size, setFocus }) {
+  if (!imageConfig) {
+    return null;
+  }
+
+  const url = buildImageUrl({
+    config: imageConfig,
+    size,
+    path: movie.poster_path
+  });
+
+  return (
+    <img
+      alt={'Poster for ' + movie.title}
+      src={url}
+      title={getMovieTitle(movie)}
+      onClick={() => setFocus(movie)}
+    />
+  );
+}
+
+function getMovieTitle(movie) {
+  return `${movie.title} (${new Date(movie.release_date).getFullYear()})`;
+}

--- a/src/app/admin/users/peek/page.jsx
+++ b/src/app/admin/users/peek/page.jsx
@@ -7,38 +7,39 @@ import useTmdbImageConfig from '@/hooks/useTmdbImageConfig';
 import { buildImageUrl } from '@/lib/buildImageUrl';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
-import { useState } from 'react';
+import { Suspense, useState } from 'react';
 
 export default function AuthAdminUserPeek({ params: asyncParams }) {
-  const searchParams = useSearchParams();
-  const username = searchParams.get('username');
-  const rankingSlug = searchParams.get('ranking');
   const imageConfig = useTmdbImageConfig();
 
   return (
     <AdminAuthenticatedPage asyncParams={asyncParams}>
       {({ session, params, router }) => {
-        if (!searchParams.has('username') || !searchParams.has('ranking')) {
-          return 'This page requires ?username=x&ranking=y';
-        }
         return (
-          <AdminUserPeek
-            session={session}
-            params={params}
-            username={username}
-            rankingSlug={rankingSlug}
-            router={router}
-            imageConfig={imageConfig}
-          />
+          <Suspense>
+            <AdminUserPeek
+              session={session}
+              params={params}
+              router={router}
+              imageConfig={imageConfig}
+            />
+          </Suspense>
         );
       }}
     </AdminAuthenticatedPage>
   );
 }
 
-function AdminUserPeek({ username, rankingSlug, imageConfig }) {
+function AdminUserPeek({ imageConfig }) {
   const [focusMovie, setFocusMovie] = useState(null);
+  const searchParams = useSearchParams();
+  const username = searchParams.get('username');
+  const rankingSlug = searchParams.get('ranking');
   const { ranking, lists } = useRankingForUser({ username, rankingSlug });
+
+  if (!searchParams.has('username') || !searchParams.has('ranking')) {
+    return 'This page requires ?username={username}&ranking={ranking-slug}';
+  }
 
   if (!ranking || !lists) {
     return null;

--- a/src/app/rankings/[username]/[rankingSlug]/page.jsx
+++ b/src/app/rankings/[username]/[rankingSlug]/page.jsx
@@ -14,6 +14,7 @@ import {
 } from '@/lib/db';
 import { MenuBar } from '@/app/rankings/[username]/[rankingSlug]/components/MenuBar';
 import { PathAuthenticatedPage } from '@/components/AuthenticatedPage';
+import useTmdbImageConfig from '@/hooks/useTmdbImageConfig';
 
 export default function AuthRankingPage({ params: asyncParams }) {
   return (
@@ -34,10 +35,11 @@ function RankingPage({ params, user, session, router }) {
   const [lists, setLists] = useState(INITIAL_LISTS);
   const [ranking, setRanking] = useState(null);
   const [listForModal, setListForModal] = useState(null);
-  const [imageConfig, setImageConfig] = useState(null);
   const [alert, setAlert] = useState({});
   const [alertVisible, setAlertVisible] = useState(false);
   const [importVisible, setImportVisible] = useState(false);
+
+  const imageConfig = useTmdbImageConfig();
 
   useEffect(() => {
     async function retrieve() {
@@ -63,15 +65,6 @@ function RankingPage({ params, user, session, router }) {
 
     retrieve();
   }, [params, user, session, router, setLists, setRanking]);
-
-  useEffect(() => {
-    async function retrieveTmdbConfig() {
-      const config = await getTmdbConfig();
-      setImageConfig(config.images);
-    }
-
-    retrieveTmdbConfig();
-  }, [setImageConfig]);
 
   const resetAlert = useCallback(
     (newAlert) => {

--- a/src/components/AuthenticatedPage.jsx
+++ b/src/components/AuthenticatedPage.jsx
@@ -37,7 +37,7 @@ export function AuthenticatedPage({ children, asyncParams, type }) {
     const isAdmin = session.user.role === 'ADMIN';
     logger.debug(`Logged in user role: ${session.user.role}`);
 
-    if (!isAdmin && type === 'session-path-match') {
+    if (type === 'session-path-match') {
       if (!user) {
         logger.debug(
           'Checking for session-path-match auth but user.username is not available yet'

--- a/src/components/BasicTable.jsx
+++ b/src/components/BasicTable.jsx
@@ -1,0 +1,91 @@
+import { Card, Typography } from '@/components/MaterialTailwind';
+
+/**
+ *
+ * columns: [
+ *   {
+ *     label: "Name", // can also be a function, receives the whole column
+ *     key: "name",
+ *     cell: (value, row) => ReactNode // optional, will default to row[key]
+ *     cellClasses: 'space separated strings'
+ *   }
+ * ]
+ */
+
+function ColumnHead({ column }) {
+  const value =
+    typeof column.label === 'function' ? (
+      column.label(column)
+    ) : (
+      <Typography
+        variant="small"
+        color="blue-gray"
+        className="font-normal leading-none opacity-70">
+        {column.label}
+      </Typography>
+    );
+
+  return (
+    <th className="border-b border-blue-gray-100 bg-blue-gray-50 p-4 px-8">
+      {value}
+    </th>
+  );
+}
+
+function Cell({ row, column, rowIndex, columnIndex }) {
+  const value =
+    typeof column.cell === 'function' ? (
+      column.cell(row, rowIndex, columnIndex)
+    ) : (
+      <Typography variant="small" color="blue-gray" className="font-normal">
+        {row[column.key]}
+      </Typography>
+    );
+
+  return (
+    <td className={['p-3', 'px-8', column.cellClasses].join(' ')}>{value}</td>
+  );
+}
+
+export function BasicTable({ columns, rows, options = {} }) {
+  return (
+    <Card className="h-full w-full overflow-scroll">
+      <table className="w-full min-w-max table-auto text-left ">
+        <thead>
+          <tr>
+            {columns.map((column) => (
+              <ColumnHead key={column.key} column={column} />
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, rowIndex) => (
+            <tr
+              key={
+                options.getRowIndex
+                  ? options.getRowIndex(row)
+                  : 'row-' + rowIndex
+              }
+              className="even:bg-blue-gray-50/50">
+              {columns.map((column, columnIndex) => (
+                <Cell
+                  key={
+                    (options.getRowIndex
+                      ? options.getRowIndex(row)
+                      : 'row-' + rowIndex) +
+                    '--' +
+                    columnIndex
+                  }
+                  row={row}
+                  column={column}
+                  rowIndex={rowIndex}
+                  columnIndex={columnIndex}
+                />
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </Card>
+  );
+}

--- a/src/components/MaterialTailwind.js
+++ b/src/components/MaterialTailwind.js
@@ -1,0 +1,10 @@
+'use client';
+
+// this file is required based on advice found here: https://www.material-tailwind.com/docs/react/guide/next#with-server-components
+
+export {
+  ThemeProvider,
+  Card,
+  Typography,
+  Button
+} from '@material-tailwind/react';

--- a/src/hooks/useRankingForUser.js
+++ b/src/hooks/useRankingForUser.js
@@ -32,7 +32,7 @@ export default function useRankingForUser({ userId, username, rankingSlug }) {
     }
 
     retrieve();
-  }, [userId, rankingSlug, setLists, setRanking]);
+  }, [userId, username, rankingSlug, setLists, setRanking]);
 
   return { lists, ranking };
 }

--- a/src/hooks/useRankingForUser.js
+++ b/src/hooks/useRankingForUser.js
@@ -1,0 +1,38 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { INITIAL_LISTS } from '@/lib/constants';
+import { getListsForUserRanking, getRankingDetailsFromSlug } from '@/lib/db';
+import * as logger from '@/lib/logger';
+
+export default function useRankingForUser({ userId, username, rankingSlug }) {
+  const [lists, setLists] = useState(INITIAL_LISTS);
+  const [ranking, setRanking] = useState(null);
+
+  useEffect(() => {
+    async function retrieve() {
+      logger.debug('retrieving ranking details and stored lists');
+
+      if (!rankingSlug || (!userId && !username)) {
+        return;
+      }
+
+      const rankingDetails = await getRankingDetailsFromSlug(rankingSlug);
+      if (!rankingDetails || !rankingDetails.slug) {
+        return;
+      }
+      setRanking(rankingDetails);
+
+      const storedLists = await getListsForUserRanking({
+        user_id: userId,
+        username,
+        ranking_slug: rankingSlug
+      });
+      setLists(storedLists);
+    }
+
+    retrieve();
+  }, [userId, rankingSlug, setLists, setRanking]);
+
+  return { lists, ranking };
+}

--- a/src/hooks/useTmdbImageConfig.js
+++ b/src/hooks/useTmdbImageConfig.js
@@ -1,0 +1,19 @@
+'use client';
+
+import { getTmdbConfig } from '@/lib/getTmdbConfig';
+import { useState, useEffect } from 'react';
+
+export default function useTmdbImageConfig() {
+  const [config, setConfig] = useState(null);
+
+  useEffect(() => {
+    async function retrieveTmdbConfig() {
+      const config = await getTmdbConfig();
+      setConfig(config.images);
+    }
+
+    retrieveTmdbConfig();
+  }, [setConfig]);
+
+  return config;
+}

--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -215,10 +215,35 @@ function sortMoviesIntoLists(movies) {
   }, init);
 }
 
-export async function getListsForUserRanking({ user_id, ranking_slug }) {
+export async function getListsForUserRanking({
+  user_id,
+  username,
+  ranking_slug
+}) {
   logger.debug(
-    `Attempting to get lists for user ${user_id} for ranking ${ranking_slug} `
+    `Attempting to get lists for user ${user_id} / ${username} for ranking ${ranking_slug} `
   );
+
+  if (!user_id && !username) {
+    throw new Error(
+      'Must provide either user_id or username to get lists for user'
+    );
+  }
+
+  if (!user_id && username) {
+    const user = await prisma.user.findFirst({
+      where: {
+        username
+      }
+    });
+    if (!user) {
+      throw new Error(
+        `User not found for username ${username} while getting lists for ranking`
+      );
+    }
+    user_id = user.id;
+  }
+
   const movies = await prisma.listEntry.findMany({
     where: {
       user_id,

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,17 +1,21 @@
 /** @type {import('tailwindcss').Config} */
-export default {
+
+// Based on instructions found here: https://www.material-tailwind.com/docs/react/guide/next
+const withMT = require('@material-tailwind/react/utils/withMT');
+
+export default withMT({
   content: [
-    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
-    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
-    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+    './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/components/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/app/**/*.{js,ts,jsx,tsx,mdx}'
   ],
   theme: {
     extend: {
       colors: {
-        background: "var(--background)",
-        foreground: "var(--foreground)",
-      },
-    },
+        background: 'var(--background)',
+        foreground: 'var(--foreground)'
+      }
+    }
   },
-  plugins: [],
-};
+  plugins: []
+});


### PR DESCRIPTION
The table at /admin/users is now using the Material Tailwind library. Due to how NextJS works in App Router mode, we need to re-export all components we want to use from that library in a file prefixed with `'use client';` so we now have src/components/MaterialTailwind.js for that purpose. 

See: https://www.material-tailwind.com/docs/react/guide/next

Users table looks like this

![Screenshot 2025-02-24 at 7 00 02 AM](https://github.com/user-attachments/assets/316453d0-7218-4c8f-b8f3-b9ca4ce200cc)

In addition, I was uncomfortable with admin access to the actual edit pages, so I created a new view at /admin/users/peek, which is now linked to from the above users table. The "All Time" links go to something like this:

![Screenshot 2025-02-24 at 7 00 38 AM](https://github.com/user-attachments/assets/3e77a5a4-2117-445c-9263-7fa96dd3d390)

If you try to go to someone else's rankings/{username}/{rankingName} page you get bounced even if you are admin.

And last, if you click any of the movie posters in the peek grid, it opens bigger preview, mostly for mobile since we don't show the titles. You can hover on desktop and get the HTML "title" but that won't work on mobile so click opens the preview. 

![Screenshot 2025-02-24 at 7 01 00 AM](https://github.com/user-attachments/assets/24e78791-630c-401c-aaaf-393bda62b674)

